### PR TITLE
Refactor profile screens to use Firestore user data

### DIFF
--- a/android/app/.cxx/Debug/3fc67703/arm64-v8a/configure_fingerprint.bin
+++ b/android/app/.cxx/Debug/3fc67703/arm64-v8a/configure_fingerprint.bin
@@ -2,27 +2,27 @@ C/C++ Structured Logg
 e
 cC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\arm64-v8a\additional_project_files.txtC
 A
-?com.android.build.gradle.internal.cxx.io.EncodedFileFingerPrint	¯Ûœ¯ÿ2 Ÿğ°Ëş2d
+?com.android.build.gradle.internal.cxx.io.EncodedFileFingerPrint	²Ë³ÿ2 Ÿğ°Ëş2d
 b
-`C:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\arm64-v8a\android_gradle_build.json	¯Ûœ¯ÿ2Í ¡ğ°Ëş2i
+`C:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\arm64-v8a\android_gradle_build.json	²Ë³ÿ2Í ¡ğ°Ëş2i
 g
-eC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\arm64-v8a\android_gradle_build_mini.json	¯Ûœ¯ÿ2” ¤ğ°Ëş2V
+eC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\arm64-v8a\android_gradle_build_mini.json	²Ë³ÿ2” ¤ğ°Ëş2V
 T
-RC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\arm64-v8a\build.ninja	¯Ûœ¯ÿ2Ïå ¶ï°Ëş2Z
+RC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\arm64-v8a\build.ninja	²Ë³ÿ2Ïå ¶ï°Ëş2Z
 X
-VC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\arm64-v8a\build.ninja.txt	¯Ûœ¯ÿ2_
+VC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\arm64-v8a\build.ninja.txt	²Ë³ÿ2_
 ]
-[C:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\arm64-v8a\build_file_index.txt	°Ûœ¯ÿ2K «ğ°Ëş2`
+[C:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\arm64-v8a\build_file_index.txt	²Ë³ÿ2K «ğ°Ëş2`
 ^
-\C:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\arm64-v8a\compile_commands.json	°Ûœ¯ÿ2d
+\C:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\arm64-v8a\compile_commands.json	²Ë³ÿ2d
 b
-`C:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\arm64-v8a\compile_commands.json.bin	°Ûœ¯ÿ2	j
+`C:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\arm64-v8a\compile_commands.json.bin	²Ë³ÿ2	j
 h
-fC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\arm64-v8a\metadata_generation_command.txt	°Ûœ¯ÿ2
+fC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\arm64-v8a\metadata_generation_command.txt	²Ë³ÿ2
 ß ªğ°Ëş2]
 [
-YC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\arm64-v8a\prefab_config.json	°Ûœ¯ÿ2( ªğ°Ëş2b
+YC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\arm64-v8a\prefab_config.json	²Ë³ÿ2( ªğ°Ëş2b
 `
-^C:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\arm64-v8a\symbol_folder_index.txt	°Ûœ¯ÿ2U ªğ°Ëş2O
+^C:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\arm64-v8a\symbol_folder_index.txt	²Ë³ÿ2U ªğ°Ëş2O
 M
-KC:\src\flutter\packages\flutter_tools\gradle\src\main\groovy\CMakeLists.txt	°Ûœ¯ÿ2§ Åï˜í2
+KC:\src\flutter\packages\flutter_tools\gradle\src\main\groovy\CMakeLists.txt	²Ë³ÿ2§ Åï˜í2

--- a/android/app/.cxx/Debug/3fc67703/armeabi-v7a/configure_fingerprint.bin
+++ b/android/app/.cxx/Debug/3fc67703/armeabi-v7a/configure_fingerprint.bin
@@ -2,27 +2,27 @@ C/C++ Structured Logi
 g
 eC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\armeabi-v7a\additional_project_files.txtC
 A
-?com.android.build.gradle.internal.cxx.io.EncodedFileFingerPrint	¾Ûœ¯ÿ2 ïø°Ëş2f
+?com.android.build.gradle.internal.cxx.io.EncodedFileFingerPrint	¿Ë³ÿ2 ïø°Ëş2f
 d
-bC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\armeabi-v7a\android_gradle_build.json	¾Ûœ¯ÿ2Ñ ñø°Ëş2k
+bC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\armeabi-v7a\android_gradle_build.json	¿Ë³ÿ2Ñ ñø°Ëş2k
 i
-gC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\armeabi-v7a\android_gradle_build_mini.json	¾Ûœ¯ÿ2˜ òø°Ëş2X
+gC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\armeabi-v7a\android_gradle_build_mini.json	¿Ë³ÿ2˜ òø°Ëş2X
 V
-TC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\armeabi-v7a\build.ninja	¾Ûœ¯ÿ2Ùå œø°Ëş2\
+TC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\armeabi-v7a\build.ninja	¿Ë³ÿ2Ùå œø°Ëş2\
 Z
-XC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\armeabi-v7a\build.ninja.txt	¾Ûœ¯ÿ2a
+XC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\armeabi-v7a\build.ninja.txt	¿Ë³ÿ2a
 _
-]C:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\armeabi-v7a\build_file_index.txt	¾Ûœ¯ÿ2K óø°Ëş2b
+]C:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\armeabi-v7a\build_file_index.txt	¿Ë³ÿ2K óø°Ëş2b
 `
-^C:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\armeabi-v7a\compile_commands.json	¾Ûœ¯ÿ2f
+^C:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\armeabi-v7a\compile_commands.json	¿Ë³ÿ2f
 d
-bC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\armeabi-v7a\compile_commands.json.bin	¾Ûœ¯ÿ2	l
+bC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\armeabi-v7a\compile_commands.json.bin	¿Ë³ÿ2	l
 j
-hC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\armeabi-v7a\metadata_generation_command.txt	¾Ûœ¯ÿ2
+hC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\armeabi-v7a\metadata_generation_command.txt	¿Ë³ÿ2
 é óø°Ëş2_
 ]
-[C:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\armeabi-v7a\prefab_config.json	¾Ûœ¯ÿ2( óø°Ëş2d
+[C:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\armeabi-v7a\prefab_config.json	¿Ë³ÿ2( óø°Ëş2d
 b
-`C:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\armeabi-v7a\symbol_folder_index.txt	¾Ûœ¯ÿ2W óø°Ëş2O
+`C:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\armeabi-v7a\symbol_folder_index.txt	¿Ë³ÿ2W óø°Ëş2O
 M
-KC:\src\flutter\packages\flutter_tools\gradle\src\main\groovy\CMakeLists.txt	¾Ûœ¯ÿ2§ Åï˜í2
+KC:\src\flutter\packages\flutter_tools\gradle\src\main\groovy\CMakeLists.txt	¿Ë³ÿ2§ Åï˜í2

--- a/android/app/.cxx/Debug/3fc67703/x86/configure_fingerprint.bin
+++ b/android/app/.cxx/Debug/3fc67703/x86/configure_fingerprint.bin
@@ -2,27 +2,27 @@ C/C++ Structured Loga
 _
 ]C:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\x86\additional_project_files.txtC
 A
-?com.android.build.gradle.internal.cxx.io.EncodedFileFingerPrint	ŸÜœ¯ÿ2 ²ƒ±Ëş2^
+?com.android.build.gradle.internal.cxx.io.EncodedFileFingerPrint	ÊË³ÿ2 ²ƒ±Ëş2^
 \
-ZC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\x86\android_gradle_build.json	ŸÜœ¯ÿ2Á ´ƒ±Ëş2c
+ZC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\x86\android_gradle_build.json	ÊË³ÿ2Á ´ƒ±Ëş2c
 a
-_C:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\x86\android_gradle_build_mini.json	ŸÜœ¯ÿ2ˆ ´ƒ±Ëş2P
+_C:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\x86\android_gradle_build_mini.json	ÊË³ÿ2ˆ ´ƒ±Ëş2P
 N
-LC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\x86\build.ninja	ŸÜœ¯ÿ2±å Ş‚±Ëş2T
+LC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\x86\build.ninja	ÊË³ÿ2±å Ş‚±Ëş2T
 R
-PC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\x86\build.ninja.txt	ŸÜœ¯ÿ2Y
+PC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\x86\build.ninja.txt	ÊË³ÿ2Y
 W
-UC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\x86\build_file_index.txt	ŸÜœ¯ÿ2K µƒ±Ëş2Z
+UC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\x86\build_file_index.txt	ÊË³ÿ2K µƒ±Ëş2Z
 X
-VC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\x86\compile_commands.json	ŸÜœ¯ÿ2^
+VC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\x86\compile_commands.json	ÊË³ÿ2^
 \
-ZC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\x86\compile_commands.json.bin	ŸÜœ¯ÿ2	d
+ZC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\x86\compile_commands.json.bin	ÊË³ÿ2	d
 b
-`C:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\x86\metadata_generation_command.txt	ŸÜœ¯ÿ2
+`C:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\x86\metadata_generation_command.txt	ÊË³ÿ2
 Á µƒ±Ëş2W
 U
-SC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\x86\prefab_config.json	ŸÜœ¯ÿ2( µƒ±Ëş2\
+SC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\x86\prefab_config.json	ÊË³ÿ2( µƒ±Ëş2\
 Z
-XC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\x86\symbol_folder_index.txt	ŸÜœ¯ÿ2O µƒ±Ëş2O
+XC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\x86\symbol_folder_index.txt	ÊË³ÿ2O µƒ±Ëş2O
 M
-KC:\src\flutter\packages\flutter_tools\gradle\src\main\groovy\CMakeLists.txt	ŸÜœ¯ÿ2§ Åï˜í2
+KC:\src\flutter\packages\flutter_tools\gradle\src\main\groovy\CMakeLists.txt	ËË³ÿ2§ Åï˜í2

--- a/android/app/.cxx/Debug/3fc67703/x86_64/configure_fingerprint.bin
+++ b/android/app/.cxx/Debug/3fc67703/x86_64/configure_fingerprint.bin
@@ -2,27 +2,27 @@ C/C++ Structured Logd
 b
 `C:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\x86_64\additional_project_files.txtC
 A
-?com.android.build.gradle.internal.cxx.io.EncodedFileFingerPrint	®Üœ¯ÿ2 ™Œ±Ëş2a
+?com.android.build.gradle.internal.cxx.io.EncodedFileFingerPrint	×Ë³ÿ2 ™Œ±Ëş2a
 _
-]C:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\x86_64\android_gradle_build.json	®Üœ¯ÿ2Ç šŒ±Ëş2f
+]C:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\x86_64\android_gradle_build.json	×Ë³ÿ2Ç šŒ±Ëş2f
 d
-bC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\x86_64\android_gradle_build_mini.json	®Üœ¯ÿ2 œŒ±Ëş2S
+bC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\x86_64\android_gradle_build_mini.json	×Ë³ÿ2 œŒ±Ëş2S
 Q
-OC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\x86_64\build.ninja	®Üœ¯ÿ2Àå ¶‹±Ëş2W
+OC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\x86_64\build.ninja	×Ë³ÿ2Àå ¶‹±Ëş2W
 U
-SC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\x86_64\build.ninja.txt	¯Üœ¯ÿ2\
+SC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\x86_64\build.ninja.txt	×Ë³ÿ2\
 Z
-XC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\x86_64\build_file_index.txt	¯Üœ¯ÿ2K Œ±Ëş2]
+XC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\x86_64\build_file_index.txt	×Ë³ÿ2K Œ±Ëş2]
 [
-YC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\x86_64\compile_commands.json	¯Üœ¯ÿ2a
+YC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\x86_64\compile_commands.json	×Ë³ÿ2a
 _
-]C:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\x86_64\compile_commands.json.bin	¯Üœ¯ÿ2	g
+]C:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\x86_64\compile_commands.json.bin	×Ë³ÿ2	g
 e
-cC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\x86_64\metadata_generation_command.txt	¯Üœ¯ÿ2
+cC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\x86_64\metadata_generation_command.txt	×Ë³ÿ2
 Ğ œŒ±Ëş2Z
 X
-VC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\x86_64\prefab_config.json	¯Üœ¯ÿ2( œŒ±Ëş2_
+VC:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\x86_64\prefab_config.json	×Ë³ÿ2( œŒ±Ëş2_
 ]
-[C:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\x86_64\symbol_folder_index.txt	¯Üœ¯ÿ2R Œ±Ëş2O
+[C:\Flutter Project\therapify\android\app\.cxx\Debug\3fc67703\x86_64\symbol_folder_index.txt	×Ë³ÿ2R Œ±Ëş2O
 M
-KC:\src\flutter\packages\flutter_tools\gradle\src\main\groovy\CMakeLists.txt	¯Üœ¯ÿ2§ Åï˜í2
+KC:\src\flutter\packages\flutter_tools\gradle\src\main\groovy\CMakeLists.txt	×Ë³ÿ2§ Åï˜í2

--- a/lib/view/screens/payment/payment_screen.dart
+++ b/lib/view/screens/payment/payment_screen.dart
@@ -55,7 +55,7 @@ class _PaymentScreenState extends State<PaymentScreen> {
                       doctor: widget.doctor,
                       selectedDate: widget.selectedDate,
                       selectedTime: widget.selectedTime,
-                      patientName: widget.patientName, // ✅ passed properly now
+                      patientId: widget.patientName, // ✅ passed properly now
                     );
                   },
                   child: Container(


### PR DESCRIPTION
Profile and edit profile screens now fetch and update user data directly from Firebase Firestore and Auth. Removed unused fields and image upload logic from edit profile, simplified form fields, and improved data handling for name, email, and phone number. Also fixed a parameter name in payment_screen.dart and cleaned up imports and UI logic in profile_screen.dart.